### PR TITLE
Fix test_endpoint.sh to use configured region 

### DIFF
--- a/edge.py
+++ b/edge.py
@@ -2,14 +2,15 @@
 vertex:edge CLI tool
 """
 import argparse
+import warnings
+import logging
 
 from edge.command.force_unlock import force_unlock
 from edge.command.experiments.subparser import add_experiments_parser, run_experiments_actions
 from edge.command.init import edge_init
 from edge.command.dvc.subparser import add_dvc_parser, run_dvc_actions
+from edge.command.misc.subparser import add_misc_parser, run_misc_actions
 from edge.command.model.subparser import add_model_parser, run_model_actions
-import warnings
-import logging
 
 logging.disable(logging.WARNING)
 warnings.filterwarnings(
@@ -31,6 +32,7 @@ if __name__ == "__main__":
     add_dvc_parser(subparsers)
     add_model_parser(subparsers)
     add_experiments_parser(subparsers)
+    add_misc_parser(subparsers)
 
     args = parser.parse_args()
 
@@ -44,5 +46,7 @@ if __name__ == "__main__":
         run_model_actions(args)
     elif args.command == "experiments":
         run_experiments_actions(args)
+    elif args.command == "misc":
+        run_misc_actions(args)
 
     raise NotImplementedError("The rest of the commands are not implemented")

--- a/edge.py
+++ b/edge.py
@@ -9,7 +9,7 @@ from edge.command.force_unlock import force_unlock
 from edge.command.experiments.subparser import add_experiments_parser, run_experiments_actions
 from edge.command.init import edge_init
 from edge.command.dvc.subparser import add_dvc_parser, run_dvc_actions
-from edge.command.misc.subparser import add_misc_parser, run_misc_actions
+from edge.command.config.subparser import add_config_parser, run_config_actions
 from edge.command.model.subparser import add_model_parser, run_model_actions
 
 logging.disable(logging.WARNING)
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     add_dvc_parser(subparsers)
     add_model_parser(subparsers)
     add_experiments_parser(subparsers)
-    add_misc_parser(subparsers)
+    add_config_parser(subparsers)
 
     args = parser.parse_args()
 
@@ -46,7 +46,7 @@ if __name__ == "__main__":
         run_model_actions(args)
     elif args.command == "experiments":
         run_experiments_actions(args)
-    elif args.command == "misc":
-        run_misc_actions(args)
+    elif args.command == "config":
+        run_config_actions(args)
 
     raise NotImplementedError("The rest of the commands are not implemented")

--- a/edge.sh
+++ b/edge.sh
@@ -7,7 +7,7 @@
 ACCOUNT=$(gcloud config get-value account)
 HOST_UID=$(id -u)
 HOST_GID=$(id -g)
-docker run -it \
+docker run -i \
  -v "$(pwd)":/project/ \
  -v ~/.config/gcloud/:/root/.config/gcloud/ \
  -e ACCOUNT="$ACCOUNT" -e HOST_UID="$HOST_UID" -e HOST_GID="$HOST_GID" \

--- a/edge/command/config/subparser.py
+++ b/edge/command/config/subparser.py
@@ -5,13 +5,13 @@ from edge.config import EdgeConfig
 from edge.exception import EdgeException
 
 
-def add_misc_parser(subparsers):
-    parser = subparsers.add_parser("misc", help="Miscellaneous actions")
+def add_config_parser(subparsers):
+    parser = subparsers.add_parser("config", help="Configuration related actions")
     actions = parser.add_subparsers(title="action", dest="action", required=True)
     actions.add_parser("get-region", help="Get configured region")
 
 
-def run_misc_actions(args: argparse.Namespace):
+def run_config_actions(args: argparse.Namespace):
     if args.action == "get-region":
         with EdgeConfig.context(silent=True) as config:
             print(config.google_cloud_project.region)

--- a/edge/command/misc/subparser.py
+++ b/edge/command/misc/subparser.py
@@ -1,0 +1,20 @@
+import argparse
+import sys
+
+from edge.config import EdgeConfig
+from edge.exception import EdgeException
+
+
+def add_misc_parser(subparsers):
+    parser = subparsers.add_parser("misc", help="Miscellaneous actions")
+    actions = parser.add_subparsers(title="action", dest="action", required=True)
+    actions.add_parser("get-region", help="Get configured region")
+
+
+def run_misc_actions(args: argparse.Namespace):
+    if args.action == "get-region":
+        with EdgeConfig.context(silent=True) as config:
+            print(config.google_cloud_project.region)
+            sys.exit(0)
+    else:
+        raise EdgeException("Unexpected experiments command")

--- a/edge_docker_entrypoint.sh
+++ b/edge_docker_entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 export GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json
-gcloud config set account "$ACCOUNT"
+gcloud config set account "$ACCOUNT" &> /dev/null
 
 if [[ $1 == "bash" ]]
 then

--- a/test_endpoint.sh
+++ b/test_endpoint.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 ENDPOINT=$(./edge.sh model get-endpoint)
+REGION=$(./edge.sh misc get-region)
 curl \
 -X POST \
 -H "Authorization: Bearer $(gcloud auth print-access-token)" \
 -H "Content-Type: application/json" \
-https://europe-west4-aiplatform.googleapis.com/v1/${ENDPOINT}:predict \
+"https://${REGION}-aiplatform.googleapis.com/v1/${ENDPOINT}:predict" \
 -d "@test_payload.json"

--- a/test_endpoint.sh
+++ b/test_endpoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ENDPOINT=$(./edge.sh model get-endpoint)
-REGION=$(./edge.sh misc get-region)
+REGION=$(./edge.sh config get-region)
 curl \
 -X POST \
 -H "Authorization: Bearer $(gcloud auth print-access-token)" \


### PR DESCRIPTION
Closing #34 

Remove -t option from docker run, so the output does not contain \r characters.
Add `misc get-region` command