### PR TITLE
Multiple models

### DIFF
--- a/edge.yaml
+++ b/edge.yaml
@@ -1,13 +1,12 @@
-experiments:
-  gke_cluster_name: sacred
-  mongodb_connection_string_secret: sacred-mongodb-connection-string
+experiments: null
 google_cloud_project:
   project_id: fuzzylabs
   region: europe-west4
 models:
-- endpoint_name: fashion-endpoint
-  name: fashion
-  prediction_server_image: gcr.io/fuzzylabs/fashion-prediction
+  fashion:
+    endpoint_name: fashion-endpoint
+    name: fashion
+    prediction_server_image: gcr.io/fuzzylabs/fashion-prediction
 storage_bucket:
   bucket_name: fashion-mnist-model
   dvc_store_directory: dvcstore

--- a/edge/command/dvc/init.py
+++ b/edge/command/dvc/init.py
@@ -15,9 +15,9 @@ Now you can version your data using DVC. See https://dvc.org/doc for more detail
 What's next? We suggest you proceed with:
 
   Train and deploy a model (see 'Training a model' section of the README for more details):
-    ./edge.sh model init
-    dvc repro {get_model_dvc_pipeline()}
-    ./edge.sh model deploy
+    ./edge.sh model init fashion
+    dvc repro {get_model_dvc_pipeline("fashion")}
+    ./edge.sh model deploy fashion
 
 Happy herding! 🐏
     """.strip()

--- a/edge/command/experiments/init.py
+++ b/edge/command/experiments/init.py
@@ -63,9 +63,9 @@ def experiments_init():
                     f"at {sacred_state.external_omniboard_string}\n\n"
                     "What's next? We suggest you proceed with:\n\n"
                     "  Train and deploy a model (see 'Training a model' section of the README for more details):\n"
-                    "    ./edge.sh model init\n"
-                    f"    dvc repro {get_model_dvc_pipeline()}\n"
-                    "    ./edge.sh model deploy\n\n"
+                    "    ./edge.sh model init fashion\n"
+                    f"    dvc repro {get_model_dvc_pipeline('fashion')}\n"
+                    "    ./edge.sh model deploy fashion\n\n"
                     "Happy herding! 🐏"
                 )
 

--- a/edge/command/init.py
+++ b/edge/command/init.py
@@ -27,9 +27,9 @@ What's next? We suggest you proceed with:
     ./edge.sh dvc init
 
   Train and deploy a model (see 'Training a model' section of the README for more details):
-    ./edge.sh model init
-    dvc repro {get_model_dvc_pipeline()}
-    ./edge.sh model deploy
+    ./edge.sh model init fashion
+    dvc repro {get_model_dvc_pipeline("fashion")}
+    ./edge.sh model deploy fashion
 
 Happy herding! 🐏
         """.strip()

--- a/edge/command/model/deploy.py
+++ b/edge/command/model/deploy.py
@@ -7,11 +7,11 @@ from edge.exception import EdgeException
 from edge.state import EdgeState
 from edge.tui import TUI, StepTUI, SubStepTUI
 from edge.vertex_deploy import vertex_deploy
-from edge.path import get_model_dvc_pipeline
+from edge.path import get_model_dvc_pipeline, get_vertex_model_json
 
 
-def model_deploy():
-    intro = "Deploying model on Vertex AI"
+def model_deploy(model_name: str):
+    intro = f"Deploying model '{model_name}' on Vertex AI"
     success_title = "Model deployed successfully"
     success_message = "Success"
     failure_title = "Model deployment failed"
@@ -28,22 +28,21 @@ def model_deploy():
             with EdgeState.context(config, to_lock=True) as state:
                 with StepTUI("Checking model configuration", emoji="🐏"):
                     with SubStepTUI("Checking that the model is initialised"):
-                        if len(config.models) == 0:
+                        if model_name not in config.models:
                             raise EdgeException("Model has not been initialised. "
-                                                "Run `./edge.sh model init` to initialise.")
-                        model_name = config.models[0].name
+                                                f"Run `./edge.sh model init {model_name}` to initialise.")
                         if state.models is None or state.models[model_name] is None:
                             raise EdgeException("Model is missing from vertex:edge state. "
                                                 "This might mean that the model has not been initialised. "
-                                                "Run `./edge.sh model init` to initialise.")
+                                                f"Run `./edge.sh model init {model_name}` to initialise.")
                         endpoint_resource_name = state.models[model_name].endpoint_resource_name
                     with SubStepTUI("Checking that the model has been trained"):
-                        if not os.path.exists("models/fashion/vertex_model.json"):
-                            raise EdgeException("models/fashion/vertex_model.json does not exist. "
+                        if not os.path.exists(get_vertex_model_json(model_name)):
+                            raise EdgeException(f"{get_vertex_model_json(model_name)} does not exist. "
                                                 "This means that the model has not been"
                                                 " trained. To train the model, "
-                                                f"run `dvc repro {get_model_dvc_pipeline()}`")
-                        with open("models/fashion/vertex_model.json") as file:
+                                                f"run `dvc repro {get_model_dvc_pipeline(model_name)}`")
+                        with open(get_vertex_model_json(model_name)) as file:
                             model_dict = json.load(file)
                         model_resource_name = model_dict["model_name"]
                 vertex_deploy(endpoint_resource_name, model_resource_name, model_name)

--- a/edge/command/model/deploy.py
+++ b/edge/command/model/deploy.py
@@ -25,7 +25,7 @@ def model_deploy(model_name: str):
                 failure_message
         ) as tui:
             precommand_checks(config)
-            with EdgeState.context(config, to_lock=True) as state:
+            with EdgeState.context(config, to_lock=True, to_save=True) as state:
                 with StepTUI("Checking model configuration", emoji="🐏"):
                     with SubStepTUI("Checking that the model is initialised"):
                         if model_name not in config.models:
@@ -46,6 +46,8 @@ def model_deploy(model_name: str):
                             model_dict = json.load(file)
                         model_resource_name = model_dict["model_name"]
                 vertex_deploy(endpoint_resource_name, model_resource_name, model_name)
+
+                state.models[model_name].deployed_model_resource_name = model_resource_name
 
                 short_endpoint_resource_name = "/".join(endpoint_resource_name.split("/")[2:])
                 tui.success_message = (

--- a/edge/command/model/describe.py
+++ b/edge/command/model/describe.py
@@ -1,0 +1,29 @@
+import sys
+from dataclasses import dataclass
+from serde import serialize
+from serde.yaml import to_yaml
+from edge.config import EdgeConfig, ModelConfig
+from edge.state import ModelState, EdgeState
+
+
+@serialize
+@dataclass
+class Description:
+    config: ModelConfig
+    state: ModelState
+
+
+def describe_model(model_name):
+    with EdgeConfig.context(silent=True) as config:
+        if model_name not in config.models:
+            print(f"'{model_name}' model is not initialised. "
+                  f"Initialise it by running `./edge.sh model init {model_name}`")
+            sys.exit(1)
+        else:
+            with EdgeState.context(config, silent=True) as state:
+                description = Description(
+                    config.models[model_name],
+                    state.models[model_name]
+                )
+                print(to_yaml(description))
+                sys.exit(0)

--- a/edge/command/model/get_endpoint.py
+++ b/edge/command/model/get_endpoint.py
@@ -5,13 +5,12 @@ from edge.state import EdgeState
 import questionary
 
 
-def get_model_endpoint():
+def get_model_endpoint(model_name: str):
     with EdgeConfig.context(silent=True) as config:
-        if config.models is None or len(config.models) == 0:
+        if config.models is None or model_name not in config.models:
             questionary.print("Model is not initialised. Initialise it by running `./edge.sh model init`.",
                               style="fg:ansired")
             sys.exit(1)
-        model_name = config.models[0].name
         with EdgeState.context(config, silent=True) as state:
             print(state.models[model_name].endpoint_resource_name)
             sys.exit(0)

--- a/edge/command/model/init.py
+++ b/edge/command/model/init.py
@@ -1,3 +1,4 @@
+import os
 import time
 from edge.command.common.precommand_check import precommand_checks
 from edge.config import EdgeConfig, ModelConfig
@@ -11,14 +12,14 @@ from edge.path import get_model_dvc_pipeline
 import questionary
 
 
-def model_init():
-    intro = "Initialising model on Vertex AI"
+def model_init(model_name: str):
+    intro = f"Initialising model '{model_name}' on Vertex AI"
     success_title = "Model initialised successfully"
     success_message = f"""
 What's next? We suggest you proceed with:
 
   Train and deploy a model (see 'Training a model' section of the README for more details):
-    dvc repro {get_model_dvc_pipeline()}
+    dvc repro {get_model_dvc_pipeline(model_name)}
     ./edge.sh model deploy
 
 Happy herding! 🐏
@@ -39,29 +40,33 @@ Happy herding! 🐏
                     with SubStepTUI("Enabling Vertex AI API for model training and deployment"):
                         enable_service_api("aiplatform.googleapis.com", config.google_cloud_project.project_id)
 
-                with StepTUI("Configuring model", emoji="⚙️"):
-                    with SubStepTUI("Configuring model name", status=TUIStatus.NEUTRAL):
-                        previous_model_name = config.models[0].name if len(config.models) > 0 else ""
-                        model_name = questionary.text(
-                            "Choose a name for your model:",
-                            default=previous_model_name,
-                            qmark=qmark,
-                            validate=(lambda x: x.strip() != "")
-                        ).ask()
-                        if model_name is None:
-                            raise EdgeException("Model name is required")
-                        model_name = model_name.strip()
+                with StepTUI(f"Configuring model '{model_name}'", emoji="⚙️"):
+                    with SubStepTUI(f"Checking if model '{model_name}' is configured") as sub_step:
+                        if model_name in config.models:
+                            sub_step.update(f"Model '{model_name}' is already configured", status=TUIStatus.WARNING)
+                            sub_step.set_dirty()
+                            if not questionary.confirm(
+                                f"Do you want to configure model '{model_name}' again?",
+                                qmark=qmark
+                            ).ask():
+                                raise EdgeException(f"Configuration for model '{model_name}' already exists")
+                        else:
+                            sub_step.update(
+                                message=f"Model '{model_name}' is not configured",
+                                status=TUIStatus.NEUTRAL
+                            )
+                    with SubStepTUI(f"Creating model '{model_name}' configuration"):
                         model_config = ModelConfig(
                             name=model_name,
                             prediction_server_image=f"gcr.io/{config.google_cloud_project.project_id}/"
                                                     f"{model_name}-prediction",
                             endpoint_name=f"{model_name}-endpoint"
                         )
-                        config.models = [model_config]
+                        config.models[model_name] = model_config
 
-                image_name = config.models[0].prediction_server_image
+                image_name = config.models[model_name].prediction_server_image
 
-                endpoint_name = config.models[0].endpoint_name
+                endpoint_name = config.models[model_name].endpoint_name
 
                 model_state = setup_endpoint(
                     config.google_cloud_project.project_id,
@@ -69,6 +74,30 @@ Happy herding! 🐏
                     endpoint_name
                 )
 
+                directory_exists = False
+                pipeline_exists = False
+                with StepTUI("Checking project directory structure", emoji="📁"):
+                    with SubStepTUI(f"Checking that 'models/{model_name}' directory exists") as sub_step:
+                        if not (os.path.exists(f"models/{model_name}") and os.path.isdir(f"models/{model_name}")):
+                            sub_step.update(
+                                message="'models/{model_name}' directory does not exist",
+                                status=TUIStatus.NEUTRAL
+                            )
+                        else:
+                            directory_exists = True
+                    if directory_exists:
+                        with SubStepTUI(f"Checking that 'models/{model_name}/dvc.yaml' pipeline exists") as sub_step:
+                            if not os.path.exists(f"models/{model_name}/dvc.yaml"):
+                                sub_step.update(
+                                    message=f"'models/{model_name}/dvc.yaml' pipeline does not exist",
+                                    status=TUIStatus.NEUTRAL
+                                )
+                            else:
+                                pipeline_exists = True
+
                 state.models = {
                     model_name: model_state
                 }
+
+                if not directory_exists or not pipeline_exists:
+                    tui.success_message = f"Note that the 'models/{model_name}" + tui.success_message

--- a/edge/command/model/list.py
+++ b/edge/command/model/list.py
@@ -1,0 +1,10 @@
+import sys
+
+from edge.config import EdgeConfig
+
+
+def list_models():
+    with EdgeConfig.context(silent=True) as config:
+        print("Configured models:")
+        print("\n".join([f" - {x}" for x in config.models.keys()]))
+        sys.exit(0)

--- a/edge/command/model/remove.py
+++ b/edge/command/model/remove.py
@@ -1,0 +1,50 @@
+import questionary
+
+from edge.command.common.precommand_check import precommand_checks
+from edge.config import EdgeConfig
+from edge.endpoint import tear_down_endpoint
+from edge.exception import EdgeException
+from edge.state import EdgeState
+from edge.tui import TUI, StepTUI, SubStepTUI, TUIStatus, qmark
+
+
+def remove_model(model_name):
+    intro = f"Removing model '{model_name}' from vertex:edge"
+    success_title = "Model removed successfully"
+    success_message = "Success"
+    failure_title = "Model removal failed"
+    failure_message = "See the errors above. See README for more details."
+    with TUI(
+        intro,
+        success_title,
+        success_message,
+        failure_title,
+        failure_message
+    ) as tui:
+        with EdgeConfig.context(to_save=True) as config:
+            precommand_checks(config)
+            with EdgeState.context(config, to_save=True, to_lock=True) as state:
+                with StepTUI(f"Checking model '{model_name}' configuration and state", emoji="🐏"):
+                    with SubStepTUI(f"Checking model '{model_name}' configuration"):
+                        if model_name not in config.models:
+                            raise EdgeException(f"'{model_name}' model is not in `edge.yaml` configuration, so it "
+                                                f"cannot be removed.")
+                    with SubStepTUI(f"Checking model '{model_name}' state"):
+                        if model_name not in state.models:
+                            raise EdgeException(f"'{model_name}' is not in vertex:edge state, which suggests that "
+                                                f"it has not been initialised. Cannot be removed")
+                    with SubStepTUI("Confirming action", status=TUIStatus.WARNING) as sub_step:
+                        sub_step.add_explanation(f"This action will undeploy '{model_name}' model from Vertex AI, "
+                                                 f"delete the Vertex AI endpoint associated with '{model_name}' model, "
+                                                 f"and remove '{model_name}' model from vertex:edge config and "
+                                                 f"state.")
+                        if not questionary.confirm("Do you want to continue?", qmark=qmark, default=False).ask():
+                            raise EdgeException("Canceled by user")
+
+                with StepTUI(f"Removing '{model_name}' model"):
+                    with SubStepTUI(f"Deleting '{state.models[model_name].endpoint_resource_name}' endpoint"):
+                        tear_down_endpoint(state.models[model_name].endpoint_resource_name)
+                    with SubStepTUI(f"Removing '{model_name}' model from config and state"):
+                        del config.models[model_name]
+                        del state.models[model_name]
+

--- a/edge/command/model/subparser.py
+++ b/edge/command/model/subparser.py
@@ -9,6 +9,7 @@ from edge.exception import EdgeException
 def add_model_parser(subparsers):
     parser = subparsers.add_parser("model", help="Model related actions")
     actions = parser.add_subparsers(title="action", dest="action", required=True)
+    parser.add_argument("model_name", metavar="model-name", help="Model name")
     actions.add_parser("init", help="Initialise model on Vertex AI")
     actions.add_parser("deploy", help="Deploy model on Vertex AI")
     actions.add_parser("get-endpoint", help="Get Vertex AI endpoint URI")
@@ -16,10 +17,10 @@ def add_model_parser(subparsers):
 
 def run_model_actions(args: argparse.Namespace):
     if args.action == "init":
-        model_init()
+        model_init(args.model_name)
     elif args.action == "deploy":
-        model_deploy()
+        model_deploy(args.model_name)
     elif args.action == "get-endpoint":
-        get_model_endpoint()
+        get_model_endpoint(args.model_name)
     else:
         raise EdgeException("Unexpected model command")

--- a/edge/command/model/subparser.py
+++ b/edge/command/model/subparser.py
@@ -1,18 +1,34 @@
 import argparse
 
 from edge.command.model.deploy import model_deploy
+from edge.command.model.describe import describe_model
 from edge.command.model.get_endpoint import get_model_endpoint
 from edge.command.model.init import model_init
+from edge.command.model.list import list_models
+from edge.command.model.remove import remove_model
 from edge.exception import EdgeException
 
 
 def add_model_parser(subparsers):
     parser = subparsers.add_parser("model", help="Model related actions")
     actions = parser.add_subparsers(title="action", dest="action", required=True)
-    parser.add_argument("model_name", metavar="model-name", help="Model name")
-    actions.add_parser("init", help="Initialise model on Vertex AI")
-    actions.add_parser("deploy", help="Deploy model on Vertex AI")
-    actions.add_parser("get-endpoint", help="Get Vertex AI endpoint URI")
+
+    init_parser = actions.add_parser("init", help="Initialise model on Vertex AI")
+    init_parser.add_argument("model_name", metavar="model-name", help="Model name")
+
+    deploy_parser = actions.add_parser("deploy", help="Deploy model on Vertex AI")
+    deploy_parser.add_argument("model_name", metavar="model-name", help="Model name")
+
+    get_endpoint_parser = actions.add_parser("get-endpoint", help="Get Vertex AI endpoint URI")
+    get_endpoint_parser.add_argument("model_name", metavar="model-name", help="Model name")
+
+    actions.add_parser("list", help="List initialised models")
+
+    describe_parser = actions.add_parser("describe", help="Describe an initialised model")
+    describe_parser.add_argument("model_name", metavar="model-name", help="Model name")
+
+    remove_parser = actions.add_parser("remove", help="Remove an initialised model from vertex:edge")
+    remove_parser.add_argument("model_name", metavar="model-name", help="Model name")
 
 
 def run_model_actions(args: argparse.Namespace):
@@ -22,5 +38,11 @@ def run_model_actions(args: argparse.Namespace):
         model_deploy(args.model_name)
     elif args.action == "get-endpoint":
         get_model_endpoint(args.model_name)
+    elif args.action == "list":
+        list_models()
+    elif args.action == "describe":
+        describe_model(args.model_name)
+    elif args.action == "remove":
+        remove_model(args.model_name)
     else:
         raise EdgeException("Unexpected model command")

--- a/edge/config.py
+++ b/edge/config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import TypeVar, Type, Optional, List
+from typing import TypeVar, Type, Optional, Dict
 from serde import serialize, deserialize
 from serde.yaml import from_yaml, to_yaml
 import os
@@ -50,7 +50,7 @@ class WebAppConfig:
     cloud_run_service_name: str
 
 
-T = TypeVar("T", bound="EdgeState")
+T = TypeVar("T", bound="EdgeConfig")
 
 
 @deserialize
@@ -60,7 +60,7 @@ class EdgeConfig:
     google_cloud_project: GCProjectConfig
     storage_bucket: StorageBucketConfig
     experiments: Optional[SacredConfig] = None
-    models: List[ModelConfig] = field(default_factory=list)
+    models: Dict[str, ModelConfig] = field(default_factory=dict)
     web_app: Optional[WebAppConfig] = None
 
     def save(self, path: str):

--- a/edge/endpoint.py
+++ b/edge/endpoint.py
@@ -80,12 +80,10 @@ def setup_endpoint(project_id: str, region: str, endpoint_name: str) -> ModelSta
                     project_id, region, endpoint_name
                 )
                 sub_step.update(message="Created 'fashion-endpoint' endpoint")
-            return ModelState(endpoint_resource_name)
+            return ModelState(endpoint_resource_name=endpoint_resource_name)
 
 
-def tear_down_endpoint(_config: EdgeConfig, _state: EdgeState):
-    print(f"# Tearing down Vertex AI endpoint: {_state.vertex_endpoint_state.endpoint_resource_name}")
-
-    endpoint = aiplatform.Endpoint(_state.vertex_endpoint_state.endpoint_resource_name)
+def tear_down_endpoint(endpoint_resource_name: str):
+    endpoint = aiplatform.Endpoint(endpoint_resource_name)
     endpoint.undeploy_all()
     endpoint.delete()

--- a/edge/path.py
+++ b/edge/path.py
@@ -1,9 +1,14 @@
 import os
 
 
-def get_model_path():
-    return "models/fashion"
+def get_model_path(model_name: str):
+    return f"models/{model_name}"
 
 
-def get_model_dvc_pipeline():
-    return os.path.join(get_model_path(), "dvc.yaml")
+def get_model_dvc_pipeline(model_name: str):
+    return os.path.join(get_model_path(model_name), "dvc.yaml")
+
+
+def get_vertex_model_json(model_name: str):
+    return os.path.join(get_model_path(model_name), "vertex_model.json")
+

--- a/edge/state.py
+++ b/edge/state.py
@@ -24,6 +24,7 @@ class SacredState:
 @dataclass
 class ModelState:
     endpoint_resource_name: str
+    deployed_model_resource_name: Optional[str] = None
 
 
 T = TypeVar("T", bound="EdgeState")

--- a/models/fashion/train-vertex.py
+++ b/models/fashion/train-vertex.py
@@ -89,10 +89,10 @@ def main(
     # Create model on Vertex
     print("Creating model")
     serving_container_image_uri = (
-        f"{_config.models[0].prediction_server_image}:{image_tag}"
+        f"{_config.models['fashion'].prediction_server_image}:{image_tag}"
     )
     model = Model.upload(
-        display_name=_config.models[0].name,
+        display_name=_config.models["fashion"].name,
         project=_config.google_cloud_project.project_id,
         location=_config.google_cloud_project.region,
         serving_container_image_uri="europe-docker.pkg.dev/cloud-aiplatform/prediction/sklearn-cpu.0-23:latest",


### PR DESCRIPTION
Make init, get-endpoint and deploy actions take model name as the parameter.
Add list, describe and remove commands for models.

Closes #3 