### PR TITLE
Fix terminal rendering 

### DIFF
--- a/edge.sh
+++ b/edge.sh
@@ -7,7 +7,7 @@
 ACCOUNT=$(gcloud config get-value account)
 HOST_UID=$(id -u)
 HOST_GID=$(id -g)
-docker run -i \
+docker run -it \
  -v "$(pwd)":/project/ \
  -v ~/.config/gcloud/:/root/.config/gcloud/ \
  -e ACCOUNT="$ACCOUNT" -e HOST_UID="$HOST_UID" -e HOST_GID="$HOST_GID" \

--- a/test_endpoint.sh
+++ b/test_endpoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-ENDPOINT=$(./edge.sh model get-endpoint)
-REGION=$(./edge.sh config get-region)
+ENDPOINT=$(./edge.sh model get-endpoint | tr -d '\r')
+REGION=$(./edge.sh config get-region | tr -d '\r')
 curl \
 -X POST \
 -H "Authorization: Bearer $(gcloud auth print-access-token)" \


### PR DESCRIPTION
Restore the -t flag for Docker; this is needed for proper terminal behaviour.
Remove \r…… characters in outputs from edge.sh before substituting them into strings.