### PR TITLE
Prevent gcloud update message

### DIFF
--- a/edge_docker_entrypoint.sh
+++ b/edge_docker_entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 export GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json
+gcloud config set component_manager/disable_update_check true &> /dev/null
 gcloud config set account "$ACCOUNT" &> /dev/null
 
 if [[ $1 == "bash" ]]


### PR DESCRIPTION
When invoking gcloud inside Docker, we don't want it to notify about available updates. The GCloud version is fixed within the Docker image.