### PR TITLE
Added Windows Init/Versions Check Compatability and Kubectl fix

### DIFF
--- a/src/edge/versions.py
+++ b/src/edge/versions.py
@@ -2,7 +2,7 @@ import json
 import subprocess
 from dataclasses import dataclass
 from .exception import EdgeException
-
+from sys import platform
 
 @dataclass
 class Version:
@@ -31,9 +31,15 @@ class Version:
         return f"{self.major}.{self.minor}.{self.patch}"
 
 
+def get_os_which_command() -> str:
+    if platform == "linux" or platform == "linux2" or platform == "darwin":
+        return "which"
+    elif platform == "win32":
+        return "where"
+
 def command_exist(command) -> bool:
     try:
-        subprocess.check_output(f"which {command}", shell=True, stderr=subprocess.STDOUT)
+        subprocess.check_output(f"{get_os_which_command()} {command}", shell=True, stderr=subprocess.STDOUT)
         return True
     except subprocess.CalledProcessError:
         return False
@@ -56,7 +62,7 @@ def get_gcloud_version(component: str = "core") -> Version:
 def get_kubectl_version() -> Version:
     if not command_exist("kubectl"):
         raise EdgeException("Unable to locate kubectl. Please visit https://kubernetes.io/docs/tasks/tools/ for installation instructions.")
-    version_string = get_version("kubectl version --client=true --short -o json")
+    version_string = get_version("kubectl version --client=true -o json")
     return Version.from_string(json.loads(version_string)["clientVersion"]["gitVersion"])
 
 


### PR DESCRIPTION
There looks to be a lot of OS Incompatability across this CLI and this should be one of many PRs to address as I begin to test out the `edge` tool itself

I am usually a MacOS (Darwin) user but have been testing this locally on my Windows Device 

**I have checked these changes on MacOS as well as Windows and as such this will need validating on Linux**

Changes:

1.  Added `platform` switch to check for OS and change out the command used to check for exitence of the dependant CLI tools
2. Removed `--short` from the kubectl check as this doesn't work on the latest version but also earlier versions flag as deprecated. Removing this allowed me to continue testing usage of  `edge` 
`Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.`


Validation 1:
Windows producing error using `--short` (kubectl v1.28.1)
```
PS C:\Users\<redacted> kubectl version --client=true --short -o json
error: unknown flag: --short
See 'kubectl version --help' for usage.
```

MacOS producing Flag Deprecation warning (kubectl v1.27.3)

```
~ ❯❯❯ kubectl version --client=true --short -o json
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
```


Init running on Windows
```
Initialising vertex:edge
🖥️ Checking your local environment
  ✔ Checking gcloud version
  ✔ Checking kubectl version
  ✔ Checking helm version
☁️ Checking your GCP environment
  🤔 Verifying GCloud configuration
    ? Is this the correct GCloud account:`redacted` Yes
    ? Is this the correct project id: `redacted` Yes
    ? Is this the correct region: europe-west2 Yes
  ✔ ️Checking if you have authenticated with gcloud
  ✔ europe-west2 is available on Vertex AI
  ✔ Checking if project  `redacted`' exists
  ✔ Checking if billing is enabled for project  `redacted`
💾 Initialising Google Storage and vertex:edge state file
  ✔ Enabling Storage API
  🤔 Configuring Google Storage bucket
    ? Now you need to choose a name for a storage bucket that will be used for data version control, model assets and keeping track of the vertex:edge state
      NOTE: Storage bucket names must be unique and follow certain conventions. Please see the following guidelines for more information https://cloud.google.com/storage/docs/naming-buckets.
  ✔ `redacted` does not exist, creating it
  ✔ Checking if vertex:edge state file exists
  ✔ Saving state file
⚙️ Saving configuration
  ✔ Saving configuration to edge.yaml                                                                                                                                                                                                                       

Initialised successfully
```
